### PR TITLE
Theme selector

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,11 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: [
+    "../src/**/*.mdx",
+    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "!../src/config/index.@(js|jsx|mjs|ts|tsx)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,8 +3,7 @@ import type { StorybookConfig } from "@storybook/react-vite";
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "!../src/config/index.@(js|jsx|mjs|ts|tsx)",
+    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
   ],
   addons: [
     "@storybook/addon-links",

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,6 +2,10 @@
   href="https://unpkg.com/@fortawesome/fontawesome-free@5.13.0/css/all.css"
   rel="stylesheet"
 />
+<link
+href="https://cdn.jsdelivr.net/npm/@markdownspace/markdownswatch/css/default.css"
+rel="stylesheet"
+/>
 <script>
   document.documentElement.setAttribute("data-theme", "light");
 </script>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -50,25 +50,32 @@ export const Hero = ({ children, color, size, withNavbar }: HeroProps) => {
   );
 };
 
-export interface HeroTitleProps extends ComponentProps<"p"> {
+
+export interface HeroTitleProps extends ComponentProps<'p'> {
   children: ReactNode;
+  color?: Color;
 }
 
-export const HeroTitle = ({ children, style }: HeroTitleProps) => {
+export const HeroTitle  = ({ children, style, color, ...props }: HeroTitleProps) => {
+  const colorClass = color ? `has-text-${color}` : '';
+
   return (
-    <p className="title" style={style}>
+    <p className={`title ${colorClass}`} style={style} {...props}>
       {children}
     </p>
   );
 };
 
-export interface HeroSubtitleProps extends ComponentProps<"p"> {
+export interface HeroSubtitleProps extends ComponentProps<'p'> {
   children: ReactNode;
+  color?: Color; 
 }
 
-export const HeroSubtitle = ({ children, style }: HeroSubtitleProps) => {
+export const HeroSubtitle = ({ children, style, color, ...props }: HeroSubtitleProps) => {
+  const colorClass = color ? `has-text-${color}` : '';
+
   return (
-    <p className="subtitle" style={style}>
+    <p className={`subtitle ${colorClass}`} style={style} {...props}>
       {children}
     </p>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,7 +14,7 @@ export type NavbarDropdownProps = {
 };
 
 export type EndButtonProps = {
-  label: ReactNode; // Accepts any ReactNode now
+  label: ReactNode;
   color?: Color;
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,7 +14,7 @@ export type NavbarDropdownProps = {
 };
 
 export type EndButtonProps = {
-  label: string;
+  label: ReactNode; // Accepts any ReactNode now
   color?: Color;
 };
 
@@ -99,10 +99,17 @@ export const Navbar = ({
           <div className="navbar-end">
             <div className="navbar-item">
               <div className="buttons">
-                {endButtons?.map((button) => (
-                  <Button key={button.label} color={button.color || "primary"}>
-                    {button.label}
-                  </Button>
+                {endButtons?.map((button, index) => (
+                  // Check if label is a component or plain text
+                  <span key={index} className="button-wrapper">
+                    {typeof button.label === 'string' ? (
+                      <Button color={button.color || "primary"}>
+                        {button.label}
+                      </Button>
+                    ) : (
+                      button.label
+                    )}
+                  </span>
                 ))}
               </div>
             </div>

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,11 +1,16 @@
-import React, { useEffect, useState, FC } from 'react';
+import React, { useEffect, useState, FC, useMemo, useRef } from 'react';
 import { Select } from './Select';
 import Themes from '../config/themes';
 
-const updateThemeStylesheet = (url: string, onLoad: () => void, context: Document = document) => {
-  const existingLink = context.getElementById('theme-stylesheet') as HTMLLinkElement;
+const updateThemeStylesheet = (
+  url: string,
+  onLoad: () => void,
+  id: string,
+  context: Document = document
+) => {
+  const existingLink = context.getElementById(id) as HTMLLinkElement;
   const newLink = context.createElement('link');
-  newLink.id = 'theme-stylesheet-temp';
+  newLink.id = `${id}-temp`;
   newLink.rel = 'stylesheet';
   newLink.href = url;
 
@@ -13,7 +18,12 @@ const updateThemeStylesheet = (url: string, onLoad: () => void, context: Documen
     if (existingLink) {
       existingLink.remove();
     }
-    newLink.id = 'theme-stylesheet';
+    newLink.id = id;
+    onLoad();
+  };
+
+  newLink.onerror = () => {
+    newLink.remove();
     onLoad();
   };
 
@@ -33,31 +43,41 @@ interface Theme {
 
 interface ThemeSelectorProps {
   filter?: (theme: Theme) => boolean;
-  initialTheme?: string; 
+  initialTheme?: string;
 }
 
 const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialTheme }) => {
-  const filteredThemes = Themes.filter(filter);
-  const defaultTheme = initialTheme || filteredThemes[0].id;
+  const filteredThemes = useMemo(() => Themes.filter(filter), [filter]);
+  const defaultTheme = initialTheme || filteredThemes[0]?.id;
   const [currentTheme, setCurrentTheme] = useState(defaultTheme);
   const [loading, setLoading] = useState(false);
+  const uniqueId = useRef(`theme-stylesheet-${Math.random().toString(36).substr(2, 9)}`).current;
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
+    // Skip the effect on the first render
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
     const selectedTheme = filteredThemes.find(theme => theme.id === currentTheme);
     const dataTheme = selectedTheme?.dataTheme || 'user';
     const themeURL = `https://cdn.jsdelivr.net/npm/@markdownspace/markdownswatch/css/${currentTheme}.css`;
 
     setLoading(true);
-    updateThemeStylesheet(themeURL, () => setLoading(false));
+    updateThemeStylesheet(themeURL, () => setLoading(false), uniqueId);
     document.documentElement.setAttribute('data-theme', dataTheme);
+
+    // No cleanup necessary since we don't want to remove the theme on unmount
   }, [currentTheme, filteredThemes]);
 
   const handleThemeChange = (value: string) => setCurrentTheme(value);
 
   const selectOptions = filteredThemes.map(theme => ({
-    value: theme.id, 
+    value: theme.id,
     label: theme.name.charAt(0).toUpperCase() + theme.name.slice(1),
-    disabled: false
+    disabled: false,
   }));
 
   return (

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -8,21 +8,19 @@ const updateThemeStylesheet = (
   id: string,
   context: Document = document
 ) => {
-  const existingLink = context.getElementById(id) as HTMLLinkElement;
+  const themeLinks = context.querySelectorAll(
+    'link[href*="markdownswatch"]'
+  );
+  themeLinks.forEach((link) => link.remove());
+
   const newLink = context.createElement('link');
-  newLink.id = `${id}-temp`;
+  newLink.id = id;
   newLink.rel = 'stylesheet';
   newLink.href = url;
 
-  newLink.onload = () => {
-    if (existingLink) {
-      existingLink.remove();
-    }
-    newLink.id = id;
-    onLoad();
-  };
-
+  newLink.onload = onLoad;
   newLink.onerror = () => {
+    console.error(`Failed to load theme stylesheet: ${url}`);
     newLink.remove();
     onLoad();
   };
@@ -55,7 +53,6 @@ const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialThe
   const isFirstRender = useRef(true);
 
   useEffect(() => {
-    // Skip the effect on the first render
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
@@ -68,16 +65,11 @@ const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialThe
     setLoading(true);
     updateThemeStylesheet(themeURL, () => setLoading(false), uniqueId);
     document.documentElement.setAttribute('data-theme', dataTheme);
-
-    // No cleanup necessary since we don't want to remove the theme on unmount
   }, [currentTheme, filteredThemes]);
-
-  const handleThemeChange = (value: string) => setCurrentTheme(value);
 
   const selectOptions = filteredThemes.map(theme => ({
     value: theme.id,
     label: theme.name.charAt(0).toUpperCase() + theme.name.slice(1),
-    disabled: false,
   }));
 
   return (
@@ -86,7 +78,7 @@ const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialThe
       color="primary"
       value={currentTheme}
       loading={loading}
-      onChange={(e) => handleThemeChange(e.target.value)}
+      onChange={(e) => setCurrentTheme(e.target.value)}
     />
   );
 };

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -46,7 +46,7 @@ const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialThe
   const [themes, setThemes] = useState<Theme[]>(Themes);
   const [currentTheme, setCurrentTheme] = useState(initialTheme || themes[0]?.id);
   const [loading, setLoading] = useState(false);
-  const uniqueId = useRef(`theme-stylesheet-${Math.random().toString(36).substr(2, 9)}`).current;
+  const uniqueId = useRef(`theme-stylesheet-${Math.random().toString(36).slice(2, 11)}`).current;
   const isFirstRender = useRef(true);
   const filteredThemes = useMemo(() => themes.filter(filter), [themes, filter]);
   const selectedTheme = useMemo(() => filteredThemes.find((theme) => theme.id === currentTheme) || filteredThemes[0], [currentTheme, filteredThemes]);

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,122 +1,74 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, FC } from 'react';
 import { Select } from './Select';
 import Themes from '../config/themes';
 
+const updateThemeStylesheet = (url: string, onLoad: () => void, context: Document = document) => {
+  const existingLink = context.getElementById('theme-stylesheet') as HTMLLinkElement;
+  const newLink = context.createElement('link');
+  newLink.id = 'theme-stylesheet-temp';
+  newLink.rel = 'stylesheet';
+  newLink.href = url;
 
-const updateThemeStylesheet = (
-    url: string,
-    onLoad: () => void,
-    context: Document = document
-) => {
-    const bulmaLink = context.querySelector('link[href*="bulma"]');
-    let themeLink = context.getElementById('theme-stylesheet') as HTMLLinkElement;
-
-    if (themeLink) {
-        // Check if the theme is already loaded
-        if (themeLink.href === url) {
-            onLoad();
-            return;
-        }
-        themeLink.href = url;
-    } else {
-        themeLink = context.createElement('link');
-        themeLink.id = 'theme-stylesheet';
-        themeLink.rel = 'stylesheet';
-        themeLink.href = url;
-        themeLink.onload = onLoad;
-
-        if (bulmaLink) {
-            bulmaLink.parentNode?.insertBefore(themeLink, bulmaLink.nextSibling);
-        } else {
-            context.head.appendChild(themeLink);
-        }
+  newLink.onload = () => {
+    if (existingLink) {
+      existingLink.remove();
     }
+    newLink.id = 'theme-stylesheet';
+    onLoad();
+  };
 
-    // Ensure onLoad fires after changing href if the link is already present
-    themeLink.onload = onLoad;
+  const bulmaLink = context.querySelector('link[href*="bulma"]');
+  if (bulmaLink) {
+    bulmaLink.parentNode?.insertBefore(newLink, bulmaLink.nextSibling);
+  } else {
+    context.head.appendChild(newLink);
+  }
 };
 
-interface ThemeSelectorProps {
-    themes?: Theme[];
-    isPersistent?: boolean;
+interface Theme {
+  id: string;
+  name: string;
+  dataTheme?: string;
 }
 
-const ThemeSelector: React.FC<ThemeSelectorProps> = ({
-    themes = Themes,
-    isPersistent = true,
-}) => {
-    const initialTheme = isPersistent ? localStorage.getItem('selectedTheme') || themes[0].id : themes[0].id;
-    const [currentTheme, setCurrentTheme] = useState(initialTheme);
-    const [loading, setLoading] = useState(false);
+interface ThemeSelectorProps {
+  filter?: (theme: Theme) => boolean;
+  initialTheme?: string; 
+}
 
-    useEffect(() => {
-        const selectedTheme = themes.find((theme) => theme.id === currentTheme);
-        const dataTheme = selectedTheme?.dataTheme || 'user';
-        const themeURL = `https://cdn.jsdelivr.net/npm/@markdownspace/markdownswatch/css/${currentTheme}.css`;
+const ThemeSelector: FC<ThemeSelectorProps> = ({ filter = () => true, initialTheme }) => {
+  const filteredThemes = Themes.filter(filter);
+  const defaultTheme = initialTheme || filteredThemes[0].id;
+  const [currentTheme, setCurrentTheme] = useState(defaultTheme);
+  const [loading, setLoading] = useState(false);
 
-        setLoading(true);
-        updateThemeStylesheet(themeURL, () => {
-            setLoading(false);
-        });
+  useEffect(() => {
+    const selectedTheme = filteredThemes.find(theme => theme.id === currentTheme);
+    const dataTheme = selectedTheme?.dataTheme || 'user';
+    const themeURL = `https://cdn.jsdelivr.net/npm/@markdownspace/markdownswatch/css/${currentTheme}.css`;
 
-        document.documentElement.setAttribute('data-theme', dataTheme);
+    setLoading(true);
+    updateThemeStylesheet(themeURL, () => setLoading(false));
+    document.documentElement.setAttribute('data-theme', dataTheme);
+  }, [currentTheme, filteredThemes]);
 
-        // Store the selected theme in local storage
-        if (isPersistent) {
-            console.log('Setting theme in local storage');
-            localStorage.setItem('selectedTheme', currentTheme);
-        }
-    }, [currentTheme, themes, isPersistent]);
+  const handleThemeChange = (value: string) => setCurrentTheme(value);
 
-    useEffect(() => {
-        console.log('ThemeSelector mounted');
-        const handleStorageChange = (event: StorageEvent) => {
-            console.log(event);
-            if (event.key === 'selectedTheme' && event.newValue) {
-                setCurrentTheme(event.newValue);
-            }
-        };
+  const selectOptions = filteredThemes.map(theme => ({
+    value: theme.id, 
+    label: theme.name.charAt(0).toUpperCase() + theme.name.slice(1),
+    disabled: false
+  }));
 
-        // Listen for changes to localStorage
-        window.addEventListener('storage', handleStorageChange);
-
-        // Cleanup listener on unmount
-        return () => {
-            console.log('ThemeSelector unmounted');
-            window.removeEventListener('storage', handleStorageChange);
-        };
-    }, []);
-
-    const handleThemeChange = (value: string) => {
-        setCurrentTheme(value);
-    };
-
-    const isThemeInList = themes.some((theme) => theme.id === currentTheme);
-
-    const selectOptions = [
-        ...(!isThemeInList ? [{
-            value: currentTheme,
-            label: currentTheme.charAt(0).toUpperCase() + currentTheme.slice(1),
-            disabled: true,
-        }] : []),
-        ...themes.map((theme) => ({
-            value: theme.id,
-            label: theme.name.charAt(0).toUpperCase() + theme.name.slice(1),
-            disabled: false
-        })),
-    ];
-
-    return (
-        <Select
-            options={selectOptions}
-            color="primary"
-            value={currentTheme}
-            loading={loading}
-            onChange={(e) => handleThemeChange(e.target.value)}
-        />
-    );
+  return (
+    <Select
+      options={selectOptions}
+      color="primary"
+      value={currentTheme}
+      loading={loading}
+      onChange={(e) => handleThemeChange(e.target.value)}
+    />
+  );
 };
 
 export default ThemeSelector;
-
-

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { Select } from './Select';
+import Themes from '../config/themes';
+
+
+const updateThemeStylesheet = (
+    url: string,
+    onLoad: () => void,
+    context: Document = document
+) => {
+    const bulmaLink = context.querySelector('link[href*="bulma"]');
+    let themeLink = context.getElementById('theme-stylesheet') as HTMLLinkElement;
+
+    if (themeLink) {
+        // Check if the theme is already loaded
+        if (themeLink.href === url) {
+            onLoad();
+            return;
+        }
+        themeLink.href = url;
+    } else {
+        themeLink = context.createElement('link');
+        themeLink.id = 'theme-stylesheet';
+        themeLink.rel = 'stylesheet';
+        themeLink.href = url;
+        themeLink.onload = onLoad;
+
+        if (bulmaLink) {
+            bulmaLink.parentNode?.insertBefore(themeLink, bulmaLink.nextSibling);
+        } else {
+            context.head.appendChild(themeLink);
+        }
+    }
+
+    // Ensure onLoad fires after changing href if the link is already present
+    themeLink.onload = onLoad;
+};
+
+interface ThemeSelectorProps {
+    themes?: Theme[];
+    isPersistent?: boolean;
+}
+
+const ThemeSelector: React.FC<ThemeSelectorProps> = ({
+    themes = Themes,
+    isPersistent = true,
+}) => {
+    const initialTheme = isPersistent ? localStorage.getItem('selectedTheme') || themes[0].id : themes[0].id;
+    const [currentTheme, setCurrentTheme] = useState(initialTheme);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const selectedTheme = themes.find((theme) => theme.id === currentTheme);
+        const dataTheme = selectedTheme?.dataTheme || 'user';
+        const themeURL = `https://cdn.jsdelivr.net/npm/@markdownspace/markdownswatch/css/${currentTheme}.css`;
+
+        setLoading(true);
+        updateThemeStylesheet(themeURL, () => {
+            setLoading(false);
+        });
+
+        document.documentElement.setAttribute('data-theme', dataTheme);
+
+        // Store the selected theme in local storage
+        if (isPersistent) {
+            console.log('Setting theme in local storage');
+            localStorage.setItem('selectedTheme', currentTheme);
+        }
+    }, [currentTheme, themes, isPersistent]);
+
+    useEffect(() => {
+        console.log('ThemeSelector mounted');
+        const handleStorageChange = (event: StorageEvent) => {
+            console.log(event);
+            if (event.key === 'selectedTheme' && event.newValue) {
+                setCurrentTheme(event.newValue);
+            }
+        };
+
+        // Listen for changes to localStorage
+        window.addEventListener('storage', handleStorageChange);
+
+        // Cleanup listener on unmount
+        return () => {
+            console.log('ThemeSelector unmounted');
+            window.removeEventListener('storage', handleStorageChange);
+        };
+    }, []);
+
+    const handleThemeChange = (value: string) => {
+        setCurrentTheme(value);
+    };
+
+    const isThemeInList = themes.some((theme) => theme.id === currentTheme);
+
+    const selectOptions = [
+        ...(!isThemeInList ? [{
+            value: currentTheme,
+            label: currentTheme.charAt(0).toUpperCase() + currentTheme.slice(1),
+            disabled: true,
+        }] : []),
+        ...themes.map((theme) => ({
+            value: theme.id,
+            label: theme.name.charAt(0).toUpperCase() + theme.name.slice(1),
+            disabled: false
+        })),
+    ];
+
+    return (
+        <Select
+            options={selectOptions}
+            color="primary"
+            value={currentTheme}
+            loading={loading}
+            onChange={(e) => handleThemeChange(e.target.value)}
+        />
+    );
+};
+
+export default ThemeSelector;
+
+

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -1,0 +1,142 @@
+const Themes: Theme[] = [
+  {
+    id: "default",
+    name: "Default",
+    description: "Bulma as-is",
+    dataTheme: "user",
+  },
+  {
+    id: "cerulean",
+    name: "Cerulean",
+    description: "A calm blue sky",
+    dataTheme: "light",
+  },
+  {
+    id: "cosmo",
+    name: "Cosmo",
+    description: "An ode to Metro",
+    dataTheme: "light",
+  },
+  {
+    id: "cyborg",
+    name: "Cyborg",
+    description: "Jet black and electric blue",
+    dataTheme: "dark",
+  },
+  {
+    id: "darkly",
+    name: "Darkly",
+    description: "Flatly in night-mode",
+    dataTheme: "dark",
+  },
+  {
+    id: "flatly",
+    name: "Flatly",
+    description: "Flat and thick",
+    dataTheme: "light",
+  },
+  {
+    id: "journal",
+    name: "Journal",
+    description: "Crisp like a new sheet of paper",
+    dataTheme: "light",
+  },
+  {
+    id: "litera",
+    name: "Litera",
+    description: "The medium is the message",
+    dataTheme: "light",
+  },
+  {
+    id: "lumen",
+    name: "Lumen",
+    description: "Light and shadow",
+    dataTheme: "light",
+  },
+  {
+    id: "lux",
+    name: "Lux",
+    description: "A touch of class",
+    dataTheme: "light",
+  },
+  {
+    id: "materia",
+    name: "Materia",
+    description: "Material is the metaphor",
+    dataTheme: "light",
+  },
+  {
+    id: "minty",
+    name: "Minty",
+    description: "A fresh feel",
+    dataTheme: "light",
+  },
+  {
+    id: "nuclear",
+    name: "Nuclear",
+    description: "A dark theme with irradiated highlights",
+    dataTheme: "dark",
+  },
+  {
+    id: "pulse",
+    name: "Pulse",
+    description: "A trace of purple",
+    dataTheme: "light",
+  },
+  {
+    id: "sandstone",
+    name: "Sandstone",
+    description: "A touch of warmth",
+    dataTheme: "light",
+  },
+  {
+    id: "simplex",
+    name: "Simplex",
+    description: "Mini and minimalist",
+    dataTheme: "light",
+  },
+  {
+    id: "slate",
+    name: "Slate",
+    description: "Shades of gunmetal gray",
+    dataTheme: "dark",
+  },
+  {
+    id: "solar",
+    name: "Solar",
+    description: "A spin on Solarized",
+    dataTheme: "dark",
+  },
+  {
+    id: "spacelab",
+    name: "Spacelab",
+    description: "Silvery and sleek",
+    dataTheme: "light",
+  },
+  {
+    id: "superhero",
+    name: "Superhero",
+    description: "The brave and the blue",
+    dataTheme: "dark",
+  },
+  {
+    id: "united",
+    name: "United",
+    description: "Ubuntu orange and unique font",
+    dataTheme: "light",
+  },
+  {
+    id: "yeti",
+    name: "Yeti",
+    description: "A friendly foundation",
+    dataTheme: "light",
+  },
+  {
+    id: "unicorn",
+    name: "Unicorn",
+    description: "Whimsy that makes you barf",
+    dataTheme: "light",
+  },
+];
+
+export default Themes;

--- a/src/stories/Navbar.stories.tsx
+++ b/src/stories/Navbar.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { EndButtonProps, Navbar } from "../components/Navbar";
+import ThemeSelector from "../components/ThemeSelector";
 
 const meta: Meta<typeof Navbar> = {
   title: "Components/Navbar",
@@ -98,6 +99,17 @@ export const WithoutStartItems: Story = {
   args: {
     ...Default.args,
     startItems: undefined,
+  },
+};
+
+export const NavbarWithThemeSelector: Story = {
+  args: {
+    ...Default.args,
+    endButtons: [
+      {
+        label: <ThemeSelector />,
+      },
+    ],
   },
 };
 

--- a/src/stories/ThemeSelector.stories.tsx
+++ b/src/stories/ThemeSelector.stories.tsx
@@ -1,47 +1,60 @@
 // ThemeSelector.stories.tsx
-import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 import ThemeSelector from '../components/ThemeSelector';
-import Themes from '../src/config/themes';
-
-// Define your themes data or import it from a central place
+import { Hero, HeroTitle, HeroSubtitle } from '../components/Hero';
 
 export default {
-    title: 'Components/ThemeSelector',
-    component: ThemeSelector,
-    parameters: {
-        layout: 'centered',
-        docs: {
-            description: {
-                component:
-                    'A Theme Selector component that allows you to switch between different CSS themes dynamically, overriding Bulma styles.',
-            },
-        },
+  title: 'Components/ThemeSelector',
+  component: ThemeSelector,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A Theme Selector component that allows you to switch between different CSS themes dynamically, overriding Bulma styles.',
+      },
     },
-    tags: ['autodocs'],
+  },
+  tags: ['autodocs'],
 } satisfies Meta<typeof ThemeSelector>;
 
 type Story = StoryObj<typeof ThemeSelector>;
 
-// Filter themes for light mode
+// Default story showcasing only the ThemeSelector without additional wrapping
+export const Default: Story = {
+  render: () => <ThemeSelector />,
+};
+
+// Story showcasing ThemeSelector within a Hero for Light themes
 export const LightThemes: Story = {
-    render: () => (
-        <ThemeSelector
-            themes={Themes.filter((theme) => theme.dataTheme === 'light')}
-        />
-    ),
+  render: () => (
+    <Hero color="light" size="halfheight">
+      <HeroTitle color="primary">Light Themes</HeroTitle>
+      <HeroSubtitle color="info">Select a light theme from the dropdown below</HeroSubtitle>
+      <ThemeSelector filter={theme => theme.dataTheme === 'light'} />
+    </Hero>
+  ),
 };
 
-// Filter themes for dark mode
+// Story showcasing ThemeSelector within a Hero for Dark themes
 export const DarkThemes: Story = {
-    render: () => (
-        <ThemeSelector
-            themes={Themes.filter((theme) => theme.dataTheme === 'dark')}
-        />
-    ),
+  render: () => (
+    <Hero color="black" size="halfheight">
+      <HeroTitle color="white">Dark Themes</HeroTitle>
+      <HeroSubtitle color="info">Select a dark theme from the dropdown below</HeroSubtitle>
+      <ThemeSelector filter={theme => theme.dataTheme === 'dark'} />
+    </Hero>
+  ),
 };
 
-// Default story showing all themes
+// Default story showcasing all themes within a Hero
 export const AllThemes: Story = {
-    render: () => <ThemeSelector themes={Themes} />,
+  render: () => (
+    <Hero color="primary" size="halfheight">
+      <HeroTitle color="white">All Themes</HeroTitle>
+      <HeroSubtitle color="light">Choose any theme from the dropdown below</HeroSubtitle>
+      <ThemeSelector />
+    </Hero>
+  ),
 };

--- a/src/stories/ThemeSelector.stories.tsx
+++ b/src/stories/ThemeSelector.stories.tsx
@@ -1,0 +1,47 @@
+// ThemeSelector.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ThemeSelector from '../components/ThemeSelector';
+import Themes from '../src/config/themes';
+
+// Define your themes data or import it from a central place
+
+export default {
+    title: 'Components/ThemeSelector',
+    component: ThemeSelector,
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'A Theme Selector component that allows you to switch between different CSS themes dynamically, overriding Bulma styles.',
+            },
+        },
+    },
+    tags: ['autodocs'],
+} satisfies Meta<typeof ThemeSelector>;
+
+type Story = StoryObj<typeof ThemeSelector>;
+
+// Filter themes for light mode
+export const LightThemes: Story = {
+    render: () => (
+        <ThemeSelector
+            themes={Themes.filter((theme) => theme.dataTheme === 'light')}
+        />
+    ),
+};
+
+// Filter themes for dark mode
+export const DarkThemes: Story = {
+    render: () => (
+        <ThemeSelector
+            themes={Themes.filter((theme) => theme.dataTheme === 'dark')}
+        />
+    ),
+};
+
+// Default story showing all themes
+export const AllThemes: Story = {
+    render: () => <ThemeSelector themes={Themes} />,
+};

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,0 +1,6 @@
+type Theme = {
+  id: string;
+  name: string;
+  dataTheme: string;
+  description?: string;
+}


### PR DESCRIPTION
## Description
This PR adds the theme selector component. The theme selector component will automatically sync with markdownswatch to get the latest available themes, in addition to a preset list. The theme selector works by adding the css files as links to the head, and updating the data theme based on light/dark mode. Old themes are removed.

## Related Issue
N/A

## Changes Made
- Add theme selector
- Add theme selector stories
- Improve Navbar flexibility (endButtons now accepts nodes)
- Add Navbar with theme selector story
- Add color options to hero title
- Add color options to hero subtitle

## Screenshots / GIFs (Optional)
https://github.com/user-attachments/assets/6503a971-ee73-4440-8417-8fdc50cb2582


## Additional Notes (Optional)
